### PR TITLE
Minor improvements on hosts file and its processing, and a pronunciation enhancement

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -38,7 +38,7 @@ class PingSkill(MycroftSkill):
         if k in hosts:
             if hosts[k][0] == '1':
                 response = requests.get(hosts[k][1])
-                data = {"response": response.reason + " " +
+                data = {"response": response.reason.replace('OK','OKAY') + " " +
                         str(response.status_code)}
                 self.speak_dialog("ServerResponse", data)
             else:

--- a/__init__.py
+++ b/__init__.py
@@ -43,7 +43,7 @@ class PingSkill(MycroftSkill):
                 self.speak_dialog("ServerResponse", data)
             else:
                 status,result = commands.getstatusoutput("ping -c1 -w2 "
-                                + hosts[k][1][(hosts[k][1]).find("//")+2:])
+                                + hosts[k][1][(hosts[k][1]).find("//")+1:].replace('/',''))
                 if status == 0:
                     data = {"response": result.split('/')[5]}
                     self.speak_dialog("PingResponse", data)

--- a/hosts.txt
+++ b/hosts.txt
@@ -13,7 +13,7 @@
 
 google, 0, https://google.com
 linux, 1, https://www.linux.com
-raspberry pie, 1, https://www.raspberrypi.org/
+raspberry pi, 1, https://www.raspberrypi.org/
 raspbian, 0, raspbian.org
 yourself, 0, http://localhost
 yourself via mdns,0,mycroft.local

--- a/hosts.txt
+++ b/hosts.txt
@@ -11,8 +11,15 @@
 # often be rerouted to your internet provider's search, and will hence
 # return the status of that server, usually `OK`. So double check your URLs.
 
-google,0,https://google.com
+google, 0, https://google.com
 linux, 1, https://www.linux.com
-yourself,0, http://localhost
+raspberry pie, 1, https://www.raspberrypi.org/
+raspbian, 0, raspbian.org
+yourself, 0, http://localhost
+yourself via mdns,0,mycroft.local
 mycroft, 0, https://mycroft.ai
-
+# Below are sites that are actual remote infrastructure dependencies for the normal function of mycroft
+home, 0, home.mycroft.ai
+github, 1, https://api.github.com/meta
+python, 1, http://status.python.org/
+python package index, 1, https://pypi.python.org/pypi/request/json


### PR DESCRIPTION
- a few new entries for hosts.txt . Some reflect actual remote infrastructure dependencies and thus may even have diagnostic value for Mycroft. Also demonstrates multi word works perfectly. 
- eliminate requirement for http:// prefix (but still tolerate it) if hosts.txt entry is type 0 (ICMP ping)
- say Okay instead of "Ock" on HTTP OK 200 responses.