### PR TITLE
Pretty good ad-hoc DNS name recognition from utterance when key is not registered name

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -23,3 +23,4 @@ home, 0, home.mycroft.ai
 github, 1, https://api.github.com/meta
 python, 1, http://status.python.org/
 python package index, 1, https://pypi.python.org/pypi/request/json
+router,0, 192.168.0.1


### PR DESCRIPTION
If no registered network node is recognized in the utterance, then give a try at extracting an ad-hoc DNS domain name from utterance and resolving (using OS host command). If that succeeds, then do a normal ICMP ping on it. Else, still fall back to "no recognized net node". 
I found mycroft to actually be pretty good at interpreting TLDs.